### PR TITLE
Bypass the https://github.com/418sec/node-pdf-image/pull/1 Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,13 @@ var util = require("util");
 var exec = require("child_process").exec;
 
 function PDFImage(pdfFilePath, options) {
+  // validating the file path for invalid characters to prevent remote code execution
+  var filter_chars = /[!";|`$()&<>]/;
+  if (filter_chars.test(pdfFilePath)) {
+    console.log("\nERROR: The file path contains invalid characters\n");
+    return;
+  }
+
   if (!options) options = {};
 
   this.pdfFilePath = pdfFilePath;


### PR DESCRIPTION
Hi Huntr Dev team :),
as I had promised, I would have started working on some of yours modules.

I'd like to say that the https://github.com/418sec/node-pdf-image/pull/1 fix (which has been `verified` as fixing the RCE vuln disclosed previously), doesn't fix the issue.

The fix proposed by @mufeedvh doesn't check for the `"` (double quote) character, making an attacker able to escape anyway the `filename` passed as `argument`, leading to `argument injection`.
Also, take in mind that in the `bash world`, the `!!` (double exclamation point) can be used to refer to the last command executed in the same shell.

Chaining this 2 characters, an attacker may be able still to bypass the fix, leading anyway to RCE.
I'm attaching my `pull request` which `blacklists` also those 2 characters, in order to avoid this (unprobable, but still fully exploitable) scenario :).

Best, Mik